### PR TITLE
add transform-es2015-for-of dependency to fix babel:dist grunt task

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "dependencies": {
     "babel-plugin-transform-es2015-modules-systemjs": "^6.5.0",
+    "babel-plugin-transform-es2015-for-of": "^6.5.0",
     "babel-preset-es2015": "^6.5.0",
     "lodash": "~4.0.0"
   }


### PR DESCRIPTION
Fix grunt error in babel:dist task :
```
grunt 
Running "clean:0" (clean) task
>> 1 path cleaned.

Running "copy:src_to_dist" (copy) task
Created 1 directory, copied 9 files

Running "copy:pluginDef" (copy) task
Copied 2 files

Running "babel:dist" (babel) task
Warning: Unknown plugin "transform-es2015-for-of" specified in "base" at 1, attempted to resolve relative to "src" Use --force to continue.

Aborted due to warnings.
```