### PR TITLE
Add "bar" chart type

### DIFF
--- a/src/editor.html
+++ b/src/editor.html
@@ -4,7 +4,7 @@
 		<div class="gf-form">
 			<span class="gf-form-label width-8">Type</span>
 			<div class="gf-form-select-wrapper max-width-10">
-				<select class="gf-form-input" ng-model="ctrl.panel.pieType" ng-options="t for t in ['pie', 'donut']" ng-change="ctrl.render()"></select>
+				<select class="gf-form-input" ng-model="ctrl.panel.pieType" ng-options="t for t in ['pie', 'donut', 'bar']" ng-change="ctrl.render()"></select>
 			</div>
 		</div>
 		<div class="gf-form">

--- a/src/rendering.js
+++ b/src/rendering.js
@@ -89,7 +89,36 @@ export default function link(scope, elem, attrs, ctrl) {
     if (panel.pieType === 'donut') {
       options.series.pie.innerRadius = 0.5;
     }
-
+    else if (panel.pieType === 'bar') {
+      // Convert data to something compatible with
+      // rendering as a barchart (tick labels and proper series)
+      // Percentage values must be manually generated too.
+      var tickLabels = [];
+      var totalValue = 0;
+      for (var i =0;i<ctrl.data.length;i++){
+        tickLabels.push([i,ctrl.data[i].label]);
+      
+        var value = ctrl.data[i].data;
+        totalValue += value;
+        ctrl.data[i].data = [[i, value]];
+        ctrl.data[i].percent = 0;
+      }
+      if (totalValue > 0){
+        for (var i =0;i<ctrl.data.length;i++){
+          ctrl.data[i].percent = (ctrl.data[i].data[0][1] / totalValue) * 100;
+        }  
+      }
+    
+      // Adjust the options for bar charts
+      delete options.series.pie;
+      options.series.bars = {
+        show: true,
+        align: "center",
+        barWidth: 0.8
+      };
+      options.xaxis = {ticks: tickLabels};
+    }  
+  
     elem.html(plotCanvas);
 
     $.plot(plotCanvas, ctrl.data, options);

--- a/src/rendering.js
+++ b/src/rendering.js
@@ -40,12 +40,14 @@ export default function link(scope, elem, attrs, ctrl) {
     var height = elem.height();
 
     var size = Math.min(width, height);
-
+    size = Math.max(21, size);
+  
     var plotCanvas = $('<div></div>');
     var plotCss = {
       top: '10px',
       margin: 'auto',
       position: 'relative',
+      width: '100%',
       height: (size - 20) + 'px'
     };
 


### PR DESCRIPTION
Very simple change that allows the data to be viewed as a Bar chart instead of a Pie chart.
The existing pie chart functionality makes adding a bar chart type to grafana trivial, as the data is already prepared in the same way a bar chart would need (i.e. time has been removed from everything).

![grafana-bar-chart-pr](https://cloud.githubusercontent.com/assets/2803187/19075573/3b456700-8a91-11e6-8b33-c72eb1805d4b.png)
