### PR TITLE
Fix donut hole when panel-container is transparent

### DIFF
--- a/src/rendering.js
+++ b/src/rendering.js
@@ -55,6 +55,9 @@ export default function link(scope, elem, attrs, ctrl) {
 
     var $panelContainer = elem.parents('.panel-container');
     var backgroundColor = $panelContainer.css('background-color');
+    if (backgroundColor == 'rgba(0, 0, 0, 0)') {
+      backgroundColor = $('body').css('background-color');
+    }
 
     var options = {
       legend: {


### PR DESCRIPTION
Closes #28, #36, #45 and #56.
When the panel-container is transparent, uses the background-color of the body.

Below a screenshot of the donut with the default (non-transparent) background:

![screen shot 2017-05-17 at 16 53 37](https://cloud.githubusercontent.com/assets/2574399/26173232/7ce3e696-3b21-11e7-8550-22582feb2fa5.png)

And below a screenshot of the donut with a transparent background:

![screen shot 2017-05-17 at 16 53 47](https://cloud.githubusercontent.com/assets/2574399/26173242/8681481a-3b21-11e7-92ab-38ad3dd5fa9b.png)
