### PR TITLE
Add “Export to CSV” and “Toggle legend” menu options

### DIFF
--- a/src/piechart_ctrl.js
+++ b/src/piechart_ctrl.js
@@ -4,6 +4,7 @@ import kbn from 'app/core/utils/kbn';
 import TimeSeries from 'app/core/time_series';
 import rendering from './rendering';
 import legend from './legend';
+import * as fileExport from 'app/core/utils/file_export';
 
 export class PieChartCtrl extends MetricsPanelCtrl {
 
@@ -161,12 +162,37 @@ export class PieChartCtrl extends MetricsPanelCtrl {
   }
 
   onInitPanelActions(actions) {
+    actions.push({text: 'Export CSV', click: 'ctrl.exportCsv()'});
     actions.push({text: 'Toggle legend', click: 'ctrl.toggleLegend()'});
   }
 
   toggleLegend() {
     this.panel.legend.show = !this.panel.legend.show;
     this.refresh();
+  }
+
+  exportCsv() {
+    var seriesList = this.series;
+
+    var text = 'sep=;\n';
+    text += 'Series;Values;Percentage\n';
+
+    var total = 0;
+    for (var i = 0; i < seriesList.length; i++) {
+      total += seriesList[i].stats[this.panel.valueName];
+    }
+
+    for (i = 0; i < seriesList.length; i++) {
+      var series = seriesList[i]
+      var value = series.formatValue(series.stats[this.panel.valueName]);
+      var pvalue = ((value / total) * 100).toFixed(2) + '%';
+
+      text += series.label + ';';
+      text += value + ';';
+      text += pvalue + '\n';
+    }
+
+    fileExport.saveSaveBlob(text, 'grafana_data_export.csv');
   }
 }
 

--- a/src/piechart_ctrl.js
+++ b/src/piechart_ctrl.js
@@ -45,6 +45,7 @@ export class PieChartCtrl extends MetricsPanelCtrl {
     this.events.on('data-error', this.onDataError.bind(this));
     this.events.on('data-snapshot-load', this.onDataReceived.bind(this));
     this.events.on('init-edit-mode', this.onInitEditMode.bind(this));
+    this.events.on('init-panel-actions', this.onInitPanelActions.bind(this));
   }
 
   onInitEditMode() {
@@ -157,6 +158,15 @@ export class PieChartCtrl extends MetricsPanelCtrl {
       this.hiddenSeries[serie.label] = true;
     }
     this.render();
+  }
+
+  onInitPanelActions(actions) {
+    actions.push({text: 'Toggle legend', click: 'ctrl.toggleLegend()'});
+  }
+
+  toggleLegend() {
+    this.panel.legend.show = !this.panel.legend.show;
+    this.refresh();
   }
 }
 


### PR DESCRIPTION
This pair of commits will make the Pie Chart plugin more in-line with the core Graph panel.

This first commit adds the option to toggle the panel legend. The use case is to have the legend hidden by default but to allow the user to display it when they want to take a screenshot.

The second commit adds the option to export the chart data in CSV format. This allows for easier off-line processing. The implementation was done by cherry-picking the logic from `render()` in `legend.js`.