### PR TITLE
Add hiddenQueries to plugin.json for compatibility with Grafana 6.2+

### DIFF
--- a/dist/plugin.json
+++ b/dist/plugin.json
@@ -3,6 +3,8 @@
   "name": "Pie Chart",
   "id": "grafana-piechart-panel",
 
+  "hiddenQueries": true,
+
   "info": {
     "description": "Pie chart panel for grafana",
     "author": {

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -3,6 +3,8 @@
   "name": "Pie Chart",
   "id": "grafana-piechart-panel",
 
+  "hiddenQueries": true,
+
   "info": {
     "description": "Pie chart panel for grafana",
     "author": {


### PR DESCRIPTION
Grafana 6.2.0 introduces a breaking changes for plugins that process hidden queries (https://github.com/grafana/grafana/releases/tag/v6.2.0).
The plugin.json files need the new _hiddenQueries_ attribute to be compatible.