### PR TITLE
Docs: fixed the broken URL of grafana plugin installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ grafana-cli plugins install grafana-piechart-panel
 
 The plugin will be installed into your grafana plugins directory; the default is /var/lib/grafana/plugins if you installed the grafana package.
 
-More instructions on the cli tool can be found [here](http://docs.grafana.org/v3.0/plugins/installation/).
+More instructions on the cli tool can be found [here](https://grafana.com/docs/grafana/latest/plugins/installation/).
 
 You need the lastest grafana build for Grafana 3.0 to enable plugin support. You can get it here : http://grafana.org/download/builds.html
 


### PR DESCRIPTION
fixed the broken URL of grafana plugin installation in Readme file