### PR TITLE
Update default maxDataPoints to 1 instead of 3

### DIFF
--- a/src/piechart_ctrl.ts
+++ b/src/piechart_ctrl.ts
@@ -28,7 +28,7 @@ class PieChartCtrl extends MetricsPanelCtrl {
       },
       links: [],
       datasource: null,
-      maxDataPoints: 3,
+      maxDataPoints: 1,
       interval: null,
       targets: [{}],
       cacheTimeout: null,


### PR DESCRIPTION
This PR updates `maxDataPoints` default to 1. A few related issues:

https://github.com/grafana/piechart-panel/issues/42
https://github.com/grafana/metrictank/issues/983

Basically it's a problem with how runtime consolidation in Metrictank / Graphite deals with a small `maxDataPoints`. Setting it to 1 as default should, in most cases, be a better option and give more accurate and reproducible query results as a time window shifts to the future.